### PR TITLE
docs(README): highlight `Note` word correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   Design on <a href="https://www.figma.com/file/bwhp2Q5jdzJDIw5YIsBlXe/Full-E-Commerce-Website-UI-UX-Design-(Community)?node-id=34%3A213&mode=design" target="_blank">Figma</a>
 </p>
 
-##Note
+## Note
 <p>
   This project was featured on <a href="https://www.codewithrandom.com/2024/06/04/create-e-commerce-website-using-react" target="_blank">CodeWithRandom</a>. Please give credit to the original repository: <a href="https://github.com/Moamal-2000/e-commerce">https://github.com/Moamal-2000/e-commerce</a>
 </p>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected README heading formatting by adding a space after the Markdown prefix (changed "##Note" to "## Note") to ensure consistent rendering across Markdown viewers. Improves readability and compatibility, enhancing clarity in project documentation. No code, APIs, or configuration impacted; solely a documentation polish. No release actions required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->